### PR TITLE
[ITCR-501][DS-1436] fix: media_library_theme_reset no longer supported

### DIFF
--- a/media_library_theme_reset/media_library_theme_reset.info.yml
+++ b/media_library_theme_reset/media_library_theme_reset.info.yml
@@ -1,0 +1,5 @@
+name: 'Media Library Theme Reset'
+type: module
+description: 'Display the Media Library with an administrative theme'
+core_version_requirement: ^8 || ^9 || ^10
+package: 'Custom'

--- a/media_library_theme_reset/media_library_theme_reset.post_update.php
+++ b/media_library_theme_reset/media_library_theme_reset.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the media_library_theme_reset useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function media_library_theme_reset_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['media_library_theme_reset']);
+}


### PR DESCRIPTION
https://www.drupal.org/project/bootstrap_styles/issues/3325150
https://jet-dev.atlassian.net/browse/ITCR-501
https://yusa.atlassian.net/browse/DS-1436

# How to review

- Run hook updates, you should not see erorrs like this:
<img width="1077" alt="Screenshot 2024-04-03 at 11 47 07" src="https://github.com/YCloudYUSA/useless_machines/assets/26228931/22693c8a-80b1-48a9-aa2a-d50a5f047af4">
