### PR TITLE
[ITCR-501][DS-1436]  fix: jquery_ui_draggable no longer in distro

### DIFF
--- a/jquery_ui_draggable/jquery_ui_draggable.info.yml
+++ b/jquery_ui_draggable/jquery_ui_draggable.info.yml
@@ -1,0 +1,5 @@
+name: jQuery UI Draggable
+type: module
+description: 'Provides jQuery UI Draggable library.'
+package: jQuery UI
+core_version_requirement: ^9.2 || ^10

--- a/jquery_ui_draggable/jquery_ui_draggable.post_update.php
+++ b/jquery_ui_draggable/jquery_ui_draggable.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the jquery_ui_draggable useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function jquery_ui_draggable_reset_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['jquery_ui_draggable']);
+}


### PR DESCRIPTION
https://www.drupal.org/project/bootstrap_styles/issues/3325150
https://jet-dev.atlassian.net/browse/ITCR-501
https://yusa.atlassian.net/browse/DS-1436

# How to review

- Run hook updates, you should not see erorrs like this:

<img width="1078" alt="Screenshot 2024-04-03 at 13 13 56" src="https://github.com/YCloudYUSA/useless_machines/assets/26228931/a9605491-3bf3-47e1-a53a-a9d7e3793cc7">
