### PR TITLE
fix: media_entity_document no more supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         "drupal/quickedit": "*",
         "drupal/rdf": "*"
     },
+    "replace": {
+        "ymcatwincities/media_entity_document": "*"
+    },
     "license": "GPL-3.0-or-later",
     "minimum-stability": "dev"
 }

--- a/media_entity_document/media_entity_document.info.yml
+++ b/media_entity_document/media_entity_document.info.yml
@@ -1,0 +1,9 @@
+name: Media entity document
+description: 'Media entity local documents provider.'
+type: module
+package: Media
+core: 8.x
+core_version_requirement: ^9 || ^10 || ^11
+dependencies:
+  - media_entity
+  - entity_browser

--- a/media_entity_document/media_entity_document.post_update.php
+++ b/media_entity_document/media_entity_document.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the media_entity_document useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function media_entity_document_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['media_entity_document']);
+}


### PR DESCRIPTION
https://www.drupal.org/project/media_entity_document This module is useless with Drupal > 8.4 because it's in core.