### PR TITLE
[UPGRADE PATH] feat: uninstall redundant drupal modules

### DIFF
--- a/ckeditor/ckeditor.info.yml
+++ b/ckeditor/ckeditor.info.yml
@@ -1,0 +1,5 @@
+name: ckeditor
+type: module
+description: Dummy module to replace ckeditor 4.
+package: Useless Machines
+core_version_requirement: ^11

--- a/ckeditor/ckeditor.post_update.php
+++ b/ckeditor/ckeditor.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the ckeditor_font useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function ckeditor_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['ckeditor']);
+}

--- a/ckeditor5_font/ckeditor5_font.info.yml
+++ b/ckeditor5_font/ckeditor5_font.info.yml
@@ -1,0 +1,5 @@
+name: ckeditor5_font
+type: module
+description: Dummy module to replace ckeditor5_font.
+package: Useless Machines
+core_version_requirement: ^11

--- a/ckeditor5_font/ckeditor5_font.post_update.php
+++ b/ckeditor5_font/ckeditor5_font.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the ckeditor_font useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function ckeditor5_font_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['ckeditor5_font']);
+}

--- a/inline_entity_menu_form/inline_entity_menu_form.info.yml
+++ b/inline_entity_menu_form/inline_entity_menu_form.info.yml
@@ -1,0 +1,5 @@
+name: inline_entity_menu_form
+type: module
+description: Dummy module to replace inline_entity_menu_form.
+package: Useless Machines
+core_version_requirement: ^11

--- a/inline_entity_menu_form/inline_entity_menu_form.post_update.php
+++ b/inline_entity_menu_form/inline_entity_menu_form.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the ckeditor_font useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function inline_entity_menu_form_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['inline_entity_menu_form']);
+}


### PR DESCRIPTION
Fix error in drupal 11 alpha relrease when try to upgrade from drupal 10

<img width="1050" height="486" alt="Screenshot 2025-08-18 at 16 35 26" src="https://github.com/user-attachments/assets/8b28a272-46b5-45b6-89db-17b0514ea679" />
