### PR TITLE
Add features useless machine for Drupal 11 compatibility

### DIFF
--- a/features/features.info.yml
+++ b/features/features.info.yml
@@ -1,0 +1,5 @@
+name: features
+type: module
+description: Dummy module to replace features.
+package: Useless Machines
+core_version_requirement: ^9 || ^10 || ^11

--- a/features/features.post_update.php
+++ b/features/features.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the features useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function features_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['features']);
+}


### PR DESCRIPTION
## Summary
- Adds a useless machine for the drupal/features module
- Features module is not compatible with Drupal 11
- This replacement automatically uninstalls itself during database updates

## Changes
- Created `features/features.info.yml` with Drupal 9/10/11 compatibility
- Created `features/features.post_update.php` with self-uninstall logic
- Follows the same pattern as existing useless machines (quickedit, rdf, etc.)

## How it Works
1. When `drush updb` is run, the post_update hook executes
2. Module installer uninstalls the features module
3. Module installer automatically removes all `features_bundle` config entities
4. Site is left in a clean state without the features module

## Testing
This will be tested as part of the YUSAOpenY Drupal 11 upgrade process.