### PR TITLE
feat: Add stub modules for media_entity_video and openy_autocomplete_path

### DIFF
--- a/media_entity_video/media_entity_video.info.yml
+++ b/media_entity_video/media_entity_video.info.yml
@@ -1,0 +1,5 @@
+name: media_entity_video
+type: module
+description: Dummy module to replace media_entity_video.
+package: Useless Machines
+core_version_requirement: ^10 || ^11

--- a/media_entity_video/media_entity_video.post_update.php
+++ b/media_entity_video/media_entity_video.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the media_entity_video useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function media_entity_video_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['media_entity_video']);
+}

--- a/openy_autocomplete_path/openy_autocomplete_path.info.yml
+++ b/openy_autocomplete_path/openy_autocomplete_path.info.yml
@@ -1,0 +1,5 @@
+name: openy_autocomplete_path
+type: module
+description: Dummy module to replace openy_autocomplete_path.
+package: Useless Machines
+core_version_requirement: ^10 || ^11

--- a/openy_autocomplete_path/openy_autocomplete_path.post_update.php
+++ b/openy_autocomplete_path/openy_autocomplete_path.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the openy_autocomplete_path useless machine.
+ */
+
+/**
+ * Uninstall me.
+ */
+function openy_autocomplete_path_post_update_uninstall() {
+  \Drupal::service('module_installer')->uninstall(['openy_autocomplete_path']);
+}


### PR DESCRIPTION
## Summary

Add dummy stub modules to track and auto-uninstall deprecated modules that are incompatible with Drupal 11:

- **media_entity_video**: Deprecated media module 
- **openy_autocomplete_path**: Deprecated OpenY module

## Changes

Each stub module includes:
- `.info.yml` with Drupal 10/11 compatibility declaration
- `.post_update.php` with auto-uninstall hook function

## How It Works

When these stub modules are enabled, their `post_update` hooks will automatically uninstall them, allowing the `useless_machines` module to properly track and facilitate removal of these deprecated dependencies during Drupal upgrades.

## Testing

Verified stub module structure matches existing patterns in the repository (bartik, quickedit, etc.).

## Related

- Drupal 11 upgrade initiative for YUSAOpenY sites
- Resolves tracking warnings for sites with these modules enabled